### PR TITLE
Add details to Invalid Token error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,10 +9,22 @@ use thiserror::Error;
 pub enum Error {
     #[error("Missing TOKEN")]
     MissingToken,
+
     #[error("JWT token not valid - {0}")]
     InvalidToken(String),
+
     #[error("JWT token creation error")]
     TokenCreation,
+}
+
+impl Error {
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Error::MissingToken => StatusCode::UNAUTHORIZED,
+            Error::InvalidToken(_) => StatusCode::NOT_FOUND,
+            Error::TokenCreation => StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -23,13 +35,6 @@ struct ErrorResponse {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        match self {
-            Error::MissingToken =>
-                (StatusCode::UNAUTHORIZED, self.to_string()).into_response(),
-            Error::InvalidToken(_) =>
-                (StatusCode::NOT_FOUND, self.to_string()).into_response(),
-            Error::TokenCreation =>
-                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
-        }
+        (self.status(), self.to_string()).into_response()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("Missing TOKEN")]
     MissingToken,
-    #[error("JWT token not valid")]
-    InvalidToken,
+    #[error("JWT token not valid - {0}")]
+    InvalidToken(String),
     #[error("JWT token creation error")]
     TokenCreation,
 }
@@ -24,11 +24,12 @@ struct ErrorResponse {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {
-            Error::MissingToken => (StatusCode::UNAUTHORIZED, self.to_string()).into_response(),
-            Error::InvalidToken => (StatusCode::NOT_FOUND, self.to_string()).into_response(),
-            Error::TokenCreation => {
+            Error::MissingToken =>
+                (StatusCode::UNAUTHORIZED, self.to_string()).into_response(),
+            Error::InvalidToken(_) =>
+                (StatusCode::NOT_FOUND, self.to_string()).into_response(),
+            Error::TokenCreation =>
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
-            }
         }
     }
 }


### PR DESCRIPTION
## Motivation
When getting an **invalid token** response, sometimes we want to know why it failed. Is it because the token expired, wasn't found in the internal registry, or was a general error?

## Description
Extend the `InvalidToken` enum with a String parameter